### PR TITLE
fix: #111 "drop on right/ bottom of heightmap"

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -568,7 +568,7 @@ function sanatizeWatermap(map, xOffset, yOffset) {
     let watermap = Create2DArray(citiesmapSize, 0);
 
     for (let y = yOffset; y < yOffset + citiesmapSize; y++) {
-        for (let x = xOffset; x < yOffset + citiesmapSize; x++) {
+        for (let x = xOffset; x < xOffset + citiesmapSize; x++) {
             let h = map[y][x];
             watermap[y - yOffset][x - xOffset] = h;
         }


### PR DESCRIPTION
cause: watermap is generated wrongly - it is cut off at right or bottom side, depending on map size.